### PR TITLE
Livedisplay: Fix color profiles in livedisplay.

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -523,14 +523,14 @@
          the predefined and translated strings in the Settings
          app, they can be remapped here. The format is
          "oldname:newname", one per entry. -->
-    <string-array name="config_displayModeMappings" translatable="false">
+<!--    <string-array name="config_displayModeMappings" translatable="false">
         <item>A_Standard:standard</item>
         <item>B_Warm mode:reading</item>
         <item>D_Cold mode:dynamic</item>
     </string-array>
-
+-->
     <!-- Should we filter any display modes which are unampped? -->
-    <bool name="config_filterDisplayModes">true</bool>
+<!--    <bool name="config_filterDisplayModes">true</bool> -->
 
 
     <!-- Disable Old Qti Telephony -->


### PR DESCRIPTION
Display mode mappings contains values from **_vince_** and not **_mido_** which breaks "**Color profile**" option in livedisplay for mido without any benefit/use from those mappings. I have just commented the code responsible for that.